### PR TITLE
Add B1max handling and clean RF loader

### DIFF
--- a/dependencies/io_loadRFwaveform.m
+++ b/dependencies/io_loadRFwaveform.m
@@ -37,8 +37,6 @@
 
 function RF_struct=io_loadRFwaveform(filename,type,f0,B1max)
 
-disp('adapted io_loadRFwaveform')
-
 if nargin<4
     B1max=[];
 end
@@ -46,8 +44,6 @@ end
 if nargin<3
     f0=0;
 end
-
-
 
 if isnumeric(type)
     %If 'type' was specified to be exactly 90 degrees, set the type to 'exc';
@@ -135,7 +131,7 @@ Tp=0.005;  %assume a 5 ms rf pulse;
 
 if ~isempty(B1max)
     %B1max is given in mikro tesla
-    gamma_H_Hz_T=42.577478461*1e6; % 42.577478461(18) https://physics.nist.gov/cgi-bin/cuu/Value?gammapbar
+    gamma_H_Hz_T=42.577*1e6;
     w1max=B1max*1e-6*gamma_H_Hz_T;% already in [Hz]
     tw1=Tp*w1max;
 else

--- a/run_sLASER_makebasisset.m
+++ b/run_sLASER_makebasisset.m
@@ -100,6 +100,7 @@ x=linspace(-fovX/2,fovX/2,nX); %X positions to simulate [cm]
 y=linspace(-fovY/2,fovY/2,nY);
 te=32;%timing of the pulse sequence [ms]
 centreFreq=2.02; %Centre frequency of MR spectrum [ppm]
+B1max=[]; %B1max for refocusing pulses; if empty, B1max is calculated automatically
 
 fovX=-x(1)+x(end);
 fovY=-y(1)+y(end);
@@ -129,7 +130,7 @@ end
 %--------------------------------------------------------------------------
 %Load RF waveform
 %--------------------------------------------------------------------------
-rfPulse=io_loadRFwaveform(refocWaveform,'ref',0);
+rfPulse=io_loadRFwaveform(refocWaveform,'ref',0,B1max);
 %--------------------------------------------------------------------------
 %--------------------------------------------------------------------------
 sysRef.J=0;


### PR DESCRIPTION
Pass an explicit B1max through to the RF waveform loader and set a default in the sLASER setup: run_sLASER_makebasisset now initializes B1max=[] and forwards it to io_loadRFwaveform. io_loadRFwaveform was cleaned up by removing a debug disp and extra blank lines, and the gamma_H_Hz_T constant was simplified to 42.577e6. These changes allow an explicit B1 amplitude limit to be applied when loading refocusing pulses and tidy minor code/style details.