### PR TITLE
Update run_sLASER_makebasisset.m

### DIFF
--- a/run_sLASER_makebasisset.m
+++ b/run_sLASER_makebasisset.m
@@ -86,6 +86,7 @@ show_plots=false;
 vendor='Philips';
 sequence='sLASER';
 refocWaveform='standardized_goia.txt'; %name of refocusing pulse waveform
+useShaped=false; % false=ideal PRESS via sim_press, true=shaped semi-LASER
 flip_angle=180;
 refTp=4.4496; %duration of refocusing pulses[ms]
 Npts=4096; %number of spectral points
@@ -96,13 +97,15 @@ thkX=2.4; %slice thickness of x refocusing pulse [cm]
 thkY=2.2; %slice thickness of y refocusing pulse [cm]
 fovX=3; %size of the full simulation Field of View in the x-direction [cm]
 fovY=3; %size of the full simulation Field of View in the y-direction [cm]
-nX=40; %Number of grid points to simulate in the x-direction
-nY=40; %Number of grid points to simulate in the y-direction
+nX=64; %Number of grid points to simulate in the x-direction
+nY=64; %Number of grid points to simulate in the y-direction
 x=linspace(-fovX/2,fovX/2,nX); %X positions to simulate [cm]
 y=linspace(-fovY/2,fovY/2,nY);
 te=32;%timing of the pulse sequence [ms]
 centreFreq=2.02; %Centre frequency of MR spectrum [ppm]
 B1max=[22]; %B1max for refocusing pulses; if empty, B1max is calculated automatically
+pressTau1=13.1;
+pressTau2=30-pressTau1;
 
 fovX=-x(1)+x(end);
 fovY=-y(1)+y(end);
@@ -229,11 +232,17 @@ if ~strcmp(popup_choice,'Yes')
     return;
 end
 
-
 if show_plots
     vis_flag='on'; %#ok<*UNRCH>
 else
     vis_flag='off';
+end
+
+%%JA edit: keep shaped and ideal outputs separated in subfolders
+if useShaped
+    output_folder=fullfile(output_folder,'shaped');
+else
+    output_folder=fullfile(output_folder,'ideal');
 end
 
 
@@ -257,9 +266,11 @@ for k = 1:numel(folders)
     end
 end
 %--------------------------------------------------------------------------
-%Load RF waveform
+%Load RF waveform / reference spectrum
 %--------------------------------------------------------------------------
-rfPulse=io_loadRFwaveform(refocWaveform,'ref',0,B1max);
+if useShaped
+    rfPulse=io_loadRFwaveform(refocWaveform,'ref',0,B1max);
+end
 %--------------------------------------------------------------------------
 %--------------------------------------------------------------------------
 sysRef.J=0;
@@ -267,21 +278,30 @@ sysRef.shifts=0;
 sysRef.scaleFactor=1;
 sysRef.name='Ref_0ppm';
 sysRef.centreFreq=centreFreq;
-ref=run_mysLASERShaped_fast(rfPulse,refTp,Npts,sw,lw,Bfield,thkX,thkY,x,y,te,sysRef,flip_angle);
+if useShaped
+    ref=run_mysLASERShaped_fast(rfPulse,refTp,Npts,sw,lw,Bfield,thkX,thkY,x,y,te,sysRef,flip_angle);
+else
+    ref=sim_press(Npts,sw,Bfield,lw,sysRef,pressTau1,pressTau2);
+    ref.ppm=ref.ppm+shift_in_ppm;
+end
 
 tau1=15; %fake timing
 tau2=13; %fake timing
 refjustforppmrange=sim_press(Npts,sw,Bfield,lw,sysRef,tau1,tau2);
+if ~useShaped
+    refjustforppmrange.ppm=refjustforppmrange.ppm+shift_in_ppm;
+end
 %-------------------------------------------------------------------------
 
-%------------------------------------------------
-% Shift
-%------------------------------------------------
-freqShift_hz=shift_in_ppm*(Bfield*42.577478); % in Hz
 %-------------------------------------------------------------------------
-% Add shift here for the ref
+% Add shift to the shaped simulations only
 %-------------------------------------------------------------------------
-ref.fids=ref.fids.*exp(-(1i*2*pi*freqShift_hz).*ref.t).';
+ppm_range=ref.ppm(1)-ref.ppm(end);
+ppm_per_point=ppm_range/size(ref.ppm,2);
+shift_in_points=round(shift_in_ppm/ppm_per_point);
+if useShaped
+    ref.fids=ref.fids.*exp(-1i*2*pi*shift_in_points*(0:1:(size(ref.fids,1)-1)).'/(size(ref.fids,1)));
+end
 %--------------------------------------------------------------------------
 % Additional Metabolites
 [sysETH,sysAcetate,sysAcac,sysSucc,sysGlyc,sysVal,sysAceton,sysbHBHM]=define_spin_systems;
@@ -301,18 +321,24 @@ for met_nr=1:size(spinSysList,2)
     %-------------------------------------------------------------------------
     % Simulation
     %-------------------------------------------------------------------------
-    out=run_mysLASERShaped_fast(rfPulse,refTp,Npts,sw,lw,Bfield,thkX,thkY,x,y,te,sys,flip_angle);
-
-    %add w1 max
-    out.w1max=rfPulse.w1max;
+    if useShaped
+        out=run_mysLASERShaped_fast(rfPulse,refTp,Npts,sw,lw,Bfield,thkX,thkY,x,y,te,sys,flip_angle);
+        out.w1max=rfPulse.w1max;
+    else
+        out=sim_press(Npts,sw,Bfield,lw,sys,pressTau1,pressTau2);
+        out.ppm=out.ppm+shift_in_ppm;
+        out.w1max=0; % ideal PRESS has no shaped pulse amplitude
+    end
 
     % Save before the shift -
     save([save_out_mat,filesep,spinSys],'out');
 
     %-------------------------------------------------------------------------
-    % Add shift here for every simulated metabolite
+    % Add shift only for the shaped simulations
     %-------------------------------------------------------------------------
-    out.fids=out.fids.*exp(-(1i*2*pi*freqShift_hz).*ref.t).';
+    if useShaped
+        out.fids=out.fids.*exp(-1i*2*pi*shift_in_points*(0:1:(size(out.fids,1)-1)).'/(size(out.fids,1)));
+    end
 
     %-------------------------------------------------------------------------
     % add TMS ref
@@ -343,7 +369,11 @@ for met_nr=1:size(spinSysList,2)
 end
 
 fprintf('\nRunning fit_makeLCMBasis...\n\n');
-close(101)
+if useShaped
+    close(101)
+else
+    close all;
+end
 BASIS=fit_makeLCMBasis(save_out_mat_end, false, [output_folder, filesep, basis_name], vendor, sequence, vis_flag);
 
 rmpath(genpath(main_dir));


### PR DESCRIPTION
This PR adds a useShaped toggle to run_sLASER_makebasisset.m so the script can run either the shaped semi-LASER simulation path or an ideal PRESS-based path from the same entry point.